### PR TITLE
Setup snapshot testing for the parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Testing
+
+### Snapshot Testing
+
+ClickHouse Analyzer uses [insta](https://insta.rs/docs/cli/) for snapshot testing parse outputs.
+
+When running `cargo test`, the parser will run on each SQL file in `test/inputs`. The output will be compared to "snapshots" of the previous output, which are kept in `test/snapshots`. If the new outputs differ from previous outputs, the tests will fail. New outputs can be accepted using the [`cargo insta review`](https://insta.rs/docs/quickstart/#reviewing-snapshots) command. Updates to snapshots should be committed to the repository and reviewed with related code changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,7 +28,22 @@ name = "clickhouse-analyzer"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "insta",
+ "rstest",
+ "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
@@ -33,16 +57,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -63,10 +209,131 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "syn"
@@ -77,6 +344,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -141,4 +438,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.100"
 console_error_panic_hook = "0.1.7"
+serde = { version = "1.0", features = ["derive"] }
 
 [profile.release]
 lto = true
+
+[dev-dependencies]
+insta = { version = "1.43.2", features = ["yaml"] }
+rstest = "0.26"

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,7 +1,8 @@
+use serde::Serialize;
 use std::fmt;
 
 /// ClickHouse Tokens, same as the original
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum TokenKind {
     // Base tokens
     Whitespace,
@@ -88,7 +89,7 @@ impl fmt::Display for TokenKind {
 }
 
 /// Structure representing a token in the SQL
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Token {
     pub kind: TokenKind,
     pub text: String,

--- a/src/parser/tree.rs
+++ b/src/parser/tree.rs
@@ -1,7 +1,8 @@
 use crate::lexer::token::{Token, TokenKind};
+use serde::Serialize;
 use std::fmt;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Serialize)]
 pub enum TreeKind {
     // Error handling
     ErrorTree,
@@ -117,11 +118,13 @@ pub enum TreeKind {
     BlockComment, // /* comment */
 }
 
+#[derive(Serialize)]
 pub struct Tree {
     pub kind: TreeKind,
     pub children: Vec<Child>,
 }
 
+#[derive(Serialize)]
 pub enum Child {
     Token(Token),
     Tree(Tree),

--- a/test/inputs/select/error.sql
+++ b/test/inputs/select/error.sql
@@ -1,0 +1,1 @@
+not valid sql!

--- a/test/inputs/select/two_selects.sql
+++ b/test/inputs/select/two_selects.sql
@@ -1,0 +1,21 @@
+WITH
+    a,
+    b
+SELECT
+    column_a,
+    column_b,
+    "column c",
+    json.nested.path "jsonNestedPath",
+    (SELECT sub_a FROM sub_table),
+    (column_d + column_e) + column_f,
+    testFunc(5)(column_g) + 5,
+    (SELECT 1) + (SELECT 2 FROM system."numbers") as subquery_result,
+    my_int::Array(Tuple(Array(Int64), String)) casted_tuple,
+    arrayMap((x, y) -> x + 1, (u, v) -> v + 1, [6, 7, 8, 9, (10), (SELECT 1 FROM system.numbers)]) "array thing"
+FROM table
+ORDER BY b;
+
+SELECT column_1;
+SELECT column, "quoted column", 'test', 3.14, 123;
+SELECT column_3 as c3, json.nested.path "jsonNestedPath" FROM table3;
+FROM system.numbers SELECT number WHERE number > 1 OR number < 5 AND 1=1 LIMIT 1;

--- a/test/snapshots/select__error.sql@parse.snap
+++ b/test/snapshots/select__error.sql@parse.snap
@@ -1,0 +1,5 @@
+---
+source: src/parser/parser.rs
+description: select/error.sql
+---
+parser is stuck

--- a/test/snapshots/select__two_selects.sql@parse.snap
+++ b/test/snapshots/select__two_selects.sql@parse.snap
@@ -1,0 +1,2319 @@
+---
+source: src/parser/parser.rs
+description: select/two_selects.sql
+---
+kind: File
+children:
+  - Tree:
+      kind: SelectStatement
+      children:
+        - Tree:
+            kind: WithClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: WITH
+                  start: 0
+                  end: 4
+                  line: 1
+                  column: 1
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 4
+                        end: 9
+                        line: 1
+                        column: 5
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: a
+                              start: 9
+                              end: 10
+                              line: 2
+                              column: 5
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 10
+                        end: 11
+                        line: 2
+                        column: 6
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 11
+                        end: 16
+                        line: 2
+                        column: 7
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: b
+                              start: 16
+                              end: 17
+                              line: 3
+                              column: 5
+                          - Token:
+                              kind: Whitespace
+                              text: "\n"
+                              start: 17
+                              end: 18
+                              line: 3
+                              column: 6
+        - Tree:
+            kind: SelectClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: SELECT
+                  start: 18
+                  end: 24
+                  line: 4
+                  column: 1
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 24
+                        end: 29
+                        line: 4
+                        column: 7
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: column_a
+                              start: 29
+                              end: 37
+                              line: 5
+                              column: 5
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 37
+                        end: 38
+                        line: 5
+                        column: 13
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 38
+                        end: 43
+                        line: 5
+                        column: 14
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: column_b
+                              start: 43
+                              end: 51
+                              line: 6
+                              column: 5
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 51
+                        end: 52
+                        line: 6
+                        column: 13
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 52
+                        end: 57
+                        line: 6
+                        column: 14
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: QuotedIdentifier
+                              text: "\"column c\""
+                              start: 57
+                              end: 67
+                              line: 7
+                              column: 5
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 67
+                        end: 68
+                        line: 7
+                        column: 15
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 68
+                        end: 73
+                        line: 7
+                        column: 16
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: json
+                              start: 73
+                              end: 77
+                              line: 8
+                              column: 5
+                          - Token:
+                              kind: Dot
+                              text: "."
+                              start: 77
+                              end: 78
+                              line: 8
+                              column: 9
+                          - Tree:
+                              kind: ColumnReference
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: nested
+                                    start: 78
+                                    end: 84
+                                    line: 8
+                                    column: 10
+                                - Token:
+                                    kind: Dot
+                                    text: "."
+                                    start: 84
+                                    end: 85
+                                    line: 8
+                                    column: 16
+                                - Tree:
+                                    kind: ColumnReference
+                                    children:
+                                      - Token:
+                                          kind: BareWord
+                                          text: path
+                                          start: 85
+                                          end: 89
+                                          line: 8
+                                          column: 17
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 89
+                                          end: 90
+                                          line: 8
+                                          column: 21
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: QuotedIdentifier
+                              text: "\"jsonNestedPath\""
+                              start: 90
+                              end: 106
+                              line: 8
+                              column: 22
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 106
+                        end: 107
+                        line: 8
+                        column: 38
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 107
+                        end: 112
+                        line: 8
+                        column: 39
+                    - Tree:
+                        kind: Expression
+                        children:
+                          - Token:
+                              kind: OpeningRoundBracket
+                              text: (
+                              start: 112
+                              end: 113
+                              line: 9
+                              column: 5
+                          - Tree:
+                              kind: SubqueryExpression
+                              children:
+                                - Tree:
+                                    kind: SelectStatement
+                                    children:
+                                      - Tree:
+                                          kind: SelectClause
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: SELECT
+                                                start: 113
+                                                end: 119
+                                                line: 9
+                                                column: 6
+                                            - Tree:
+                                                kind: ColumnList
+                                                children:
+                                                  - Token:
+                                                      kind: Whitespace
+                                                      text: " "
+                                                      start: 119
+                                                      end: 120
+                                                      line: 9
+                                                      column: 12
+                                                  - Tree:
+                                                      kind: ColumnReference
+                                                      children:
+                                                        - Token:
+                                                            kind: BareWord
+                                                            text: sub_a
+                                                            start: 120
+                                                            end: 125
+                                                            line: 9
+                                                            column: 13
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 125
+                                                            end: 126
+                                                            line: 9
+                                                            column: 18
+                                      - Tree:
+                                          kind: FromClause
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: FROM
+                                                start: 126
+                                                end: 130
+                                                line: 9
+                                                column: 19
+                                            - Tree:
+                                                kind: TableIdentifier
+                                                children:
+                                                  - Token:
+                                                      kind: Whitespace
+                                                      text: " "
+                                                      start: 130
+                                                      end: 131
+                                                      line: 9
+                                                      column: 23
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: sub_table
+                                                      start: 131
+                                                      end: 140
+                                                      line: 9
+                                                      column: 24
+                          - Token:
+                              kind: ClosingRoundBracket
+                              text: )
+                              start: 140
+                              end: 141
+                              line: 9
+                              column: 33
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 141
+                        end: 142
+                        line: 9
+                        column: 34
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 142
+                        end: 147
+                        line: 9
+                        column: 35
+                    - Tree:
+                        kind: BinaryExpression
+                        children:
+                          - Tree:
+                              kind: Expression
+                              children:
+                                - Token:
+                                    kind: OpeningRoundBracket
+                                    text: (
+                                    start: 147
+                                    end: 148
+                                    line: 10
+                                    column: 5
+                                - Tree:
+                                    kind: BinaryExpression
+                                    children:
+                                      - Tree:
+                                          kind: ColumnReference
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: column_d
+                                                start: 148
+                                                end: 156
+                                                line: 10
+                                                column: 6
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 156
+                                                end: 157
+                                                line: 10
+                                                column: 14
+                                      - Token:
+                                          kind: Plus
+                                          text: +
+                                          start: 157
+                                          end: 158
+                                          line: 10
+                                          column: 15
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 158
+                                          end: 159
+                                          line: 10
+                                          column: 16
+                                      - Tree:
+                                          kind: ColumnReference
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: column_e
+                                                start: 159
+                                                end: 167
+                                                line: 10
+                                                column: 17
+                                - Token:
+                                    kind: ClosingRoundBracket
+                                    text: )
+                                    start: 167
+                                    end: 168
+                                    line: 10
+                                    column: 25
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 168
+                              end: 169
+                              line: 10
+                              column: 26
+                          - Token:
+                              kind: Plus
+                              text: +
+                              start: 169
+                              end: 170
+                              line: 10
+                              column: 27
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 170
+                              end: 171
+                              line: 10
+                              column: 28
+                          - Tree:
+                              kind: ColumnReference
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: column_f
+                                    start: 171
+                                    end: 179
+                                    line: 10
+                                    column: 29
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 179
+                        end: 180
+                        line: 10
+                        column: 37
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 180
+                        end: 185
+                        line: 10
+                        column: 38
+                    - Tree:
+                        kind: BinaryExpression
+                        children:
+                          - Tree:
+                              kind: FunctionCall
+                              children:
+                                - Tree:
+                                    kind: FunctionCall
+                                    children:
+                                      - Tree:
+                                          kind: ColumnReference
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: testFunc
+                                                start: 185
+                                                end: 193
+                                                line: 11
+                                                column: 5
+                                      - Tree:
+                                          kind: ExpressionList
+                                          children:
+                                            - Token:
+                                                kind: OpeningRoundBracket
+                                                text: (
+                                                start: 193
+                                                end: 194
+                                                line: 11
+                                                column: 13
+                                            - Tree:
+                                                kind: Expression
+                                                children:
+                                                  - Tree:
+                                                      kind: NumberLiteral
+                                                      children:
+                                                        - Token:
+                                                            kind: Number
+                                                            text: "5"
+                                                            start: 194
+                                                            end: 195
+                                                            line: 11
+                                                            column: 14
+                                            - Token:
+                                                kind: ClosingRoundBracket
+                                                text: )
+                                                start: 195
+                                                end: 196
+                                                line: 11
+                                                column: 15
+                                - Tree:
+                                    kind: ExpressionList
+                                    children:
+                                      - Token:
+                                          kind: OpeningRoundBracket
+                                          text: (
+                                          start: 196
+                                          end: 197
+                                          line: 11
+                                          column: 16
+                                      - Tree:
+                                          kind: Expression
+                                          children:
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: column_g
+                                                      start: 197
+                                                      end: 205
+                                                      line: 11
+                                                      column: 17
+                                      - Token:
+                                          kind: ClosingRoundBracket
+                                          text: )
+                                          start: 205
+                                          end: 206
+                                          line: 11
+                                          column: 25
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 206
+                              end: 207
+                              line: 11
+                              column: 26
+                          - Token:
+                              kind: Plus
+                              text: +
+                              start: 207
+                              end: 208
+                              line: 11
+                              column: 27
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 208
+                              end: 209
+                              line: 11
+                              column: 28
+                          - Tree:
+                              kind: NumberLiteral
+                              children:
+                                - Token:
+                                    kind: Number
+                                    text: "5"
+                                    start: 209
+                                    end: 210
+                                    line: 11
+                                    column: 29
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 210
+                        end: 211
+                        line: 11
+                        column: 30
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 211
+                        end: 216
+                        line: 11
+                        column: 31
+                    - Tree:
+                        kind: BinaryExpression
+                        children:
+                          - Tree:
+                              kind: Expression
+                              children:
+                                - Token:
+                                    kind: OpeningRoundBracket
+                                    text: (
+                                    start: 216
+                                    end: 217
+                                    line: 12
+                                    column: 5
+                                - Tree:
+                                    kind: SubqueryExpression
+                                    children:
+                                      - Tree:
+                                          kind: SelectStatement
+                                          children:
+                                            - Tree:
+                                                kind: SelectClause
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: SELECT
+                                                      start: 217
+                                                      end: 223
+                                                      line: 12
+                                                      column: 6
+                                                  - Tree:
+                                                      kind: ColumnList
+                                                      children:
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 223
+                                                            end: 224
+                                                            line: 12
+                                                            column: 12
+                                                        - Tree:
+                                                            kind: NumberLiteral
+                                                            children:
+                                                              - Token:
+                                                                  kind: Number
+                                                                  text: "1"
+                                                                  start: 224
+                                                                  end: 225
+                                                                  line: 12
+                                                                  column: 13
+                                - Token:
+                                    kind: ClosingRoundBracket
+                                    text: )
+                                    start: 225
+                                    end: 226
+                                    line: 12
+                                    column: 14
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 226
+                              end: 227
+                              line: 12
+                              column: 15
+                          - Token:
+                              kind: Plus
+                              text: +
+                              start: 227
+                              end: 228
+                              line: 12
+                              column: 16
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 228
+                              end: 229
+                              line: 12
+                              column: 17
+                          - Tree:
+                              kind: Expression
+                              children:
+                                - Token:
+                                    kind: OpeningRoundBracket
+                                    text: (
+                                    start: 229
+                                    end: 230
+                                    line: 12
+                                    column: 18
+                                - Tree:
+                                    kind: SubqueryExpression
+                                    children:
+                                      - Tree:
+                                          kind: SelectStatement
+                                          children:
+                                            - Tree:
+                                                kind: SelectClause
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: SELECT
+                                                      start: 230
+                                                      end: 236
+                                                      line: 12
+                                                      column: 19
+                                                  - Tree:
+                                                      kind: ColumnList
+                                                      children:
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 236
+                                                            end: 237
+                                                            line: 12
+                                                            column: 25
+                                                        - Tree:
+                                                            kind: NumberLiteral
+                                                            children:
+                                                              - Token:
+                                                                  kind: Number
+                                                                  text: "2"
+                                                                  start: 237
+                                                                  end: 238
+                                                                  line: 12
+                                                                  column: 26
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 238
+                                                            end: 239
+                                                            line: 12
+                                                            column: 27
+                                            - Tree:
+                                                kind: FromClause
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: FROM
+                                                      start: 239
+                                                      end: 243
+                                                      line: 12
+                                                      column: 28
+                                                  - Tree:
+                                                      kind: TableIdentifier
+                                                      children:
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 243
+                                                            end: 244
+                                                            line: 12
+                                                            column: 32
+                                                        - Token:
+                                                            kind: BareWord
+                                                            text: system
+                                                            start: 244
+                                                            end: 250
+                                                            line: 12
+                                                            column: 33
+                                                        - Token:
+                                                            kind: Dot
+                                                            text: "."
+                                                            start: 250
+                                                            end: 251
+                                                            line: 12
+                                                            column: 39
+                                                        - Token:
+                                                            kind: QuotedIdentifier
+                                                            text: "\"numbers\""
+                                                            start: 251
+                                                            end: 260
+                                                            line: 12
+                                                            column: 40
+                                - Token:
+                                    kind: ClosingRoundBracket
+                                    text: )
+                                    start: 260
+                                    end: 261
+                                    line: 12
+                                    column: 49
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 261
+                              end: 262
+                              line: 12
+                              column: 50
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: as
+                              start: 262
+                              end: 264
+                              line: 12
+                              column: 51
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 264
+                              end: 265
+                              line: 12
+                              column: 53
+                          - Token:
+                              kind: BareWord
+                              text: subquery_result
+                              start: 265
+                              end: 280
+                              line: 12
+                              column: 54
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 280
+                        end: 281
+                        line: 12
+                        column: 69
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 281
+                        end: 286
+                        line: 12
+                        column: 70
+                    - Tree:
+                        kind: CastExpression
+                        children:
+                          - Tree:
+                              kind: ColumnReference
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: my_int
+                                    start: 286
+                                    end: 292
+                                    line: 13
+                                    column: 5
+                          - Token:
+                              kind: DoubleColon
+                              text: "::"
+                              start: 292
+                              end: 294
+                              line: 13
+                              column: 11
+                          - Tree:
+                              kind: DataType
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: Array
+                                    start: 294
+                                    end: 299
+                                    line: 13
+                                    column: 13
+                                - Tree:
+                                    kind: DataTypeParameters
+                                    children:
+                                      - Token:
+                                          kind: OpeningRoundBracket
+                                          text: (
+                                          start: 299
+                                          end: 300
+                                          line: 13
+                                          column: 18
+                                      - Tree:
+                                          kind: DataType
+                                          children:
+                                            - Token:
+                                                kind: BareWord
+                                                text: Tuple
+                                                start: 300
+                                                end: 305
+                                                line: 13
+                                                column: 19
+                                            - Tree:
+                                                kind: DataTypeParameters
+                                                children:
+                                                  - Token:
+                                                      kind: OpeningRoundBracket
+                                                      text: (
+                                                      start: 305
+                                                      end: 306
+                                                      line: 13
+                                                      column: 24
+                                                  - Tree:
+                                                      kind: DataType
+                                                      children:
+                                                        - Token:
+                                                            kind: BareWord
+                                                            text: Array
+                                                            start: 306
+                                                            end: 311
+                                                            line: 13
+                                                            column: 25
+                                                        - Tree:
+                                                            kind: DataTypeParameters
+                                                            children:
+                                                              - Token:
+                                                                  kind: OpeningRoundBracket
+                                                                  text: (
+                                                                  start: 311
+                                                                  end: 312
+                                                                  line: 13
+                                                                  column: 30
+                                                              - Tree:
+                                                                  kind: DataType
+                                                                  children:
+                                                                    - Token:
+                                                                        kind: BareWord
+                                                                        text: Int64
+                                                                        start: 312
+                                                                        end: 317
+                                                                        line: 13
+                                                                        column: 31
+                                                              - Token:
+                                                                  kind: ClosingRoundBracket
+                                                                  text: )
+                                                                  start: 317
+                                                                  end: 318
+                                                                  line: 13
+                                                                  column: 36
+                                                  - Token:
+                                                      kind: Comma
+                                                      text: ","
+                                                      start: 318
+                                                      end: 319
+                                                      line: 13
+                                                      column: 37
+                                                  - Tree:
+                                                      kind: DataType
+                                                      children:
+                                                        - Token:
+                                                            kind: Whitespace
+                                                            text: " "
+                                                            start: 319
+                                                            end: 320
+                                                            line: 13
+                                                            column: 38
+                                                        - Token:
+                                                            kind: BareWord
+                                                            text: String
+                                                            start: 320
+                                                            end: 326
+                                                            line: 13
+                                                            column: 39
+                                                  - Token:
+                                                      kind: ClosingRoundBracket
+                                                      text: )
+                                                      start: 326
+                                                      end: 327
+                                                      line: 13
+                                                      column: 45
+                                      - Token:
+                                          kind: ClosingRoundBracket
+                                          text: )
+                                          start: 327
+                                          end: 328
+                                          line: 13
+                                          column: 46
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 328
+                        end: 329
+                        line: 13
+                        column: 47
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: casted_tuple
+                              start: 329
+                              end: 341
+                              line: 13
+                              column: 48
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 341
+                        end: 342
+                        line: 13
+                        column: 60
+                    - Token:
+                        kind: Whitespace
+                        text: "\n    "
+                        start: 342
+                        end: 347
+                        line: 13
+                        column: 61
+                    - Tree:
+                        kind: FunctionCall
+                        children:
+                          - Tree:
+                              kind: ColumnReference
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: arrayMap
+                                    start: 347
+                                    end: 355
+                                    line: 14
+                                    column: 5
+                          - Tree:
+                              kind: ExpressionList
+                              children:
+                                - Token:
+                                    kind: OpeningRoundBracket
+                                    text: (
+                                    start: 355
+                                    end: 356
+                                    line: 14
+                                    column: 13
+                                - Tree:
+                                    kind: LambdaExpression
+                                    children:
+                                      - Tree:
+                                          kind: TupleExpression
+                                          children:
+                                            - Token:
+                                                kind: OpeningRoundBracket
+                                                text: (
+                                                start: 356
+                                                end: 357
+                                                line: 14
+                                                column: 14
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: x
+                                                      start: 357
+                                                      end: 358
+                                                      line: 14
+                                                      column: 15
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 358
+                                                end: 359
+                                                line: 14
+                                                column: 16
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 359
+                                                end: 360
+                                                line: 14
+                                                column: 17
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: y
+                                                      start: 360
+                                                      end: 361
+                                                      line: 14
+                                                      column: 18
+                                            - Token:
+                                                kind: ClosingRoundBracket
+                                                text: )
+                                                start: 361
+                                                end: 362
+                                                line: 14
+                                                column: 19
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 362
+                                          end: 363
+                                          line: 14
+                                          column: 20
+                                      - Token:
+                                          kind: Arrow
+                                          text: "->"
+                                          start: 363
+                                          end: 365
+                                          line: 14
+                                          column: 21
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 365
+                                          end: 366
+                                          line: 14
+                                          column: 23
+                                      - Tree:
+                                          kind: BinaryExpression
+                                          children:
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: x
+                                                      start: 366
+                                                      end: 367
+                                                      line: 14
+                                                      column: 24
+                                                  - Token:
+                                                      kind: Whitespace
+                                                      text: " "
+                                                      start: 367
+                                                      end: 368
+                                                      line: 14
+                                                      column: 25
+                                            - Token:
+                                                kind: Plus
+                                                text: +
+                                                start: 368
+                                                end: 369
+                                                line: 14
+                                                column: 26
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 369
+                                                end: 370
+                                                line: 14
+                                                column: 27
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "1"
+                                                      start: 370
+                                                      end: 371
+                                                      line: 14
+                                                      column: 28
+                                - Token:
+                                    kind: Comma
+                                    text: ","
+                                    start: 371
+                                    end: 372
+                                    line: 14
+                                    column: 29
+                                - Tree:
+                                    kind: LambdaExpression
+                                    children:
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 372
+                                          end: 373
+                                          line: 14
+                                          column: 30
+                                      - Tree:
+                                          kind: TupleExpression
+                                          children:
+                                            - Token:
+                                                kind: OpeningRoundBracket
+                                                text: (
+                                                start: 373
+                                                end: 374
+                                                line: 14
+                                                column: 31
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: u
+                                                      start: 374
+                                                      end: 375
+                                                      line: 14
+                                                      column: 32
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 375
+                                                end: 376
+                                                line: 14
+                                                column: 33
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 376
+                                                end: 377
+                                                line: 14
+                                                column: 34
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: v
+                                                      start: 377
+                                                      end: 378
+                                                      line: 14
+                                                      column: 35
+                                            - Token:
+                                                kind: ClosingRoundBracket
+                                                text: )
+                                                start: 378
+                                                end: 379
+                                                line: 14
+                                                column: 36
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 379
+                                          end: 380
+                                          line: 14
+                                          column: 37
+                                      - Token:
+                                          kind: Arrow
+                                          text: "->"
+                                          start: 380
+                                          end: 382
+                                          line: 14
+                                          column: 38
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 382
+                                          end: 383
+                                          line: 14
+                                          column: 40
+                                      - Tree:
+                                          kind: BinaryExpression
+                                          children:
+                                            - Tree:
+                                                kind: ColumnReference
+                                                children:
+                                                  - Token:
+                                                      kind: BareWord
+                                                      text: v
+                                                      start: 383
+                                                      end: 384
+                                                      line: 14
+                                                      column: 41
+                                                  - Token:
+                                                      kind: Whitespace
+                                                      text: " "
+                                                      start: 384
+                                                      end: 385
+                                                      line: 14
+                                                      column: 42
+                                            - Token:
+                                                kind: Plus
+                                                text: +
+                                                start: 385
+                                                end: 386
+                                                line: 14
+                                                column: 43
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 386
+                                                end: 387
+                                                line: 14
+                                                column: 44
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "1"
+                                                      start: 387
+                                                      end: 388
+                                                      line: 14
+                                                      column: 45
+                                - Token:
+                                    kind: Comma
+                                    text: ","
+                                    start: 388
+                                    end: 389
+                                    line: 14
+                                    column: 46
+                                - Tree:
+                                    kind: Expression
+                                    children:
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 389
+                                          end: 390
+                                          line: 14
+                                          column: 47
+                                      - Tree:
+                                          kind: ArrayExpression
+                                          children:
+                                            - Token:
+                                                kind: OpeningSquareBracket
+                                                text: "["
+                                                start: 390
+                                                end: 391
+                                                line: 14
+                                                column: 48
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "6"
+                                                      start: 391
+                                                      end: 392
+                                                      line: 14
+                                                      column: 49
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 392
+                                                end: 393
+                                                line: 14
+                                                column: 50
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 393
+                                                end: 394
+                                                line: 14
+                                                column: 51
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "7"
+                                                      start: 394
+                                                      end: 395
+                                                      line: 14
+                                                      column: 52
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 395
+                                                end: 396
+                                                line: 14
+                                                column: 53
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 396
+                                                end: 397
+                                                line: 14
+                                                column: 54
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "8"
+                                                      start: 397
+                                                      end: 398
+                                                      line: 14
+                                                      column: 55
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 398
+                                                end: 399
+                                                line: 14
+                                                column: 56
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 399
+                                                end: 400
+                                                line: 14
+                                                column: 57
+                                            - Tree:
+                                                kind: NumberLiteral
+                                                children:
+                                                  - Token:
+                                                      kind: Number
+                                                      text: "9"
+                                                      start: 400
+                                                      end: 401
+                                                      line: 14
+                                                      column: 58
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 401
+                                                end: 402
+                                                line: 14
+                                                column: 59
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 402
+                                                end: 403
+                                                line: 14
+                                                column: 60
+                                            - Tree:
+                                                kind: Expression
+                                                children:
+                                                  - Token:
+                                                      kind: OpeningRoundBracket
+                                                      text: (
+                                                      start: 403
+                                                      end: 404
+                                                      line: 14
+                                                      column: 61
+                                                  - Tree:
+                                                      kind: NumberLiteral
+                                                      children:
+                                                        - Token:
+                                                            kind: Number
+                                                            text: "10"
+                                                            start: 404
+                                                            end: 406
+                                                            line: 14
+                                                            column: 62
+                                                  - Token:
+                                                      kind: ClosingRoundBracket
+                                                      text: )
+                                                      start: 406
+                                                      end: 407
+                                                      line: 14
+                                                      column: 64
+                                            - Token:
+                                                kind: Comma
+                                                text: ","
+                                                start: 407
+                                                end: 408
+                                                line: 14
+                                                column: 65
+                                            - Token:
+                                                kind: Whitespace
+                                                text: " "
+                                                start: 408
+                                                end: 409
+                                                line: 14
+                                                column: 66
+                                            - Tree:
+                                                kind: Expression
+                                                children:
+                                                  - Token:
+                                                      kind: OpeningRoundBracket
+                                                      text: (
+                                                      start: 409
+                                                      end: 410
+                                                      line: 14
+                                                      column: 67
+                                                  - Tree:
+                                                      kind: SubqueryExpression
+                                                      children:
+                                                        - Tree:
+                                                            kind: SelectStatement
+                                                            children:
+                                                              - Tree:
+                                                                  kind: SelectClause
+                                                                  children:
+                                                                    - Token:
+                                                                        kind: BareWord
+                                                                        text: SELECT
+                                                                        start: 410
+                                                                        end: 416
+                                                                        line: 14
+                                                                        column: 68
+                                                                    - Tree:
+                                                                        kind: ColumnList
+                                                                        children:
+                                                                          - Token:
+                                                                              kind: Whitespace
+                                                                              text: " "
+                                                                              start: 416
+                                                                              end: 417
+                                                                              line: 14
+                                                                              column: 74
+                                                                          - Tree:
+                                                                              kind: NumberLiteral
+                                                                              children:
+                                                                                - Token:
+                                                                                    kind: Number
+                                                                                    text: "1"
+                                                                                    start: 417
+                                                                                    end: 418
+                                                                                    line: 14
+                                                                                    column: 75
+                                                                          - Token:
+                                                                              kind: Whitespace
+                                                                              text: " "
+                                                                              start: 418
+                                                                              end: 419
+                                                                              line: 14
+                                                                              column: 76
+                                                              - Tree:
+                                                                  kind: FromClause
+                                                                  children:
+                                                                    - Token:
+                                                                        kind: BareWord
+                                                                        text: FROM
+                                                                        start: 419
+                                                                        end: 423
+                                                                        line: 14
+                                                                        column: 77
+                                                                    - Tree:
+                                                                        kind: TableIdentifier
+                                                                        children:
+                                                                          - Token:
+                                                                              kind: Whitespace
+                                                                              text: " "
+                                                                              start: 423
+                                                                              end: 424
+                                                                              line: 14
+                                                                              column: 81
+                                                                          - Token:
+                                                                              kind: BareWord
+                                                                              text: system
+                                                                              start: 424
+                                                                              end: 430
+                                                                              line: 14
+                                                                              column: 82
+                                                                          - Token:
+                                                                              kind: Dot
+                                                                              text: "."
+                                                                              start: 430
+                                                                              end: 431
+                                                                              line: 14
+                                                                              column: 88
+                                                                          - Token:
+                                                                              kind: BareWord
+                                                                              text: numbers
+                                                                              start: 431
+                                                                              end: 438
+                                                                              line: 14
+                                                                              column: 89
+                                                  - Token:
+                                                      kind: ClosingRoundBracket
+                                                      text: )
+                                                      start: 438
+                                                      end: 439
+                                                      line: 14
+                                                      column: 96
+                                            - Token:
+                                                kind: ClosingSquareBracket
+                                                text: "]"
+                                                start: 439
+                                                end: 440
+                                                line: 14
+                                                column: 97
+                                - Token:
+                                    kind: ClosingRoundBracket
+                                    text: )
+                                    start: 440
+                                    end: 441
+                                    line: 14
+                                    column: 98
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 441
+                        end: 442
+                        line: 14
+                        column: 99
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: QuotedIdentifier
+                              text: "\"array thing\""
+                              start: 442
+                              end: 455
+                              line: 14
+                              column: 100
+                    - Token:
+                        kind: Whitespace
+                        text: "\n"
+                        start: 455
+                        end: 456
+                        line: 14
+                        column: 113
+        - Tree:
+            kind: FromClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: FROM
+                  start: 456
+                  end: 460
+                  line: 15
+                  column: 1
+              - Tree:
+                  kind: TableIdentifier
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 460
+                        end: 461
+                        line: 15
+                        column: 5
+                    - Token:
+                        kind: BareWord
+                        text: table
+                        start: 461
+                        end: 466
+                        line: 15
+                        column: 6
+                    - Token:
+                        kind: Whitespace
+                        text: "\n"
+                        start: 466
+                        end: 467
+                        line: 15
+                        column: 11
+        - Tree:
+            kind: OrderByClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: ORDER
+                  start: 467
+                  end: 472
+                  line: 16
+                  column: 1
+              - Token:
+                  kind: Whitespace
+                  text: " "
+                  start: 472
+                  end: 473
+                  line: 16
+                  column: 6
+              - Token:
+                  kind: BareWord
+                  text: BY
+                  start: 473
+                  end: 475
+                  line: 16
+                  column: 7
+              - Tree:
+                  kind: OrderByItem
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 475
+                        end: 476
+                        line: 16
+                        column: 9
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: b
+                              start: 476
+                              end: 477
+                              line: 16
+                              column: 10
+  - Token:
+      kind: Semicolon
+      text: ;
+      start: 477
+      end: 478
+      line: 16
+      column: 11
+  - Token:
+      kind: Whitespace
+      text: "\n\n"
+      start: 478
+      end: 480
+      line: 16
+      column: 12
+  - Tree:
+      kind: SelectStatement
+      children:
+        - Tree:
+            kind: SelectClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: SELECT
+                  start: 480
+                  end: 486
+                  line: 18
+                  column: 1
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 486
+                        end: 487
+                        line: 18
+                        column: 7
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: column_1
+                              start: 487
+                              end: 495
+                              line: 18
+                              column: 8
+  - Token:
+      kind: Semicolon
+      text: ;
+      start: 495
+      end: 496
+      line: 18
+      column: 16
+  - Token:
+      kind: Whitespace
+      text: "\n"
+      start: 496
+      end: 497
+      line: 18
+      column: 17
+  - Tree:
+      kind: SelectStatement
+      children:
+        - Tree:
+            kind: SelectClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: SELECT
+                  start: 497
+                  end: 503
+                  line: 19
+                  column: 1
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 503
+                        end: 504
+                        line: 19
+                        column: 7
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: column
+                              start: 504
+                              end: 510
+                              line: 19
+                              column: 8
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 510
+                        end: 511
+                        line: 19
+                        column: 14
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 511
+                        end: 512
+                        line: 19
+                        column: 15
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: QuotedIdentifier
+                              text: "\"quoted column\""
+                              start: 512
+                              end: 527
+                              line: 19
+                              column: 16
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 527
+                        end: 528
+                        line: 19
+                        column: 31
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 528
+                        end: 529
+                        line: 19
+                        column: 32
+                    - Tree:
+                        kind: StringLiteral
+                        children:
+                          - Token:
+                              kind: StringLiteral
+                              text: "'test'"
+                              start: 529
+                              end: 535
+                              line: 19
+                              column: 33
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 535
+                        end: 536
+                        line: 19
+                        column: 39
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 536
+                        end: 537
+                        line: 19
+                        column: 40
+                    - Tree:
+                        kind: NumberLiteral
+                        children:
+                          - Token:
+                              kind: Number
+                              text: "3.14"
+                              start: 537
+                              end: 541
+                              line: 19
+                              column: 41
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 541
+                        end: 542
+                        line: 19
+                        column: 45
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 542
+                        end: 543
+                        line: 19
+                        column: 46
+                    - Tree:
+                        kind: NumberLiteral
+                        children:
+                          - Token:
+                              kind: Number
+                              text: "123"
+                              start: 543
+                              end: 546
+                              line: 19
+                              column: 47
+  - Token:
+      kind: Semicolon
+      text: ;
+      start: 546
+      end: 547
+      line: 19
+      column: 50
+  - Token:
+      kind: Whitespace
+      text: "\n"
+      start: 547
+      end: 548
+      line: 19
+      column: 51
+  - Tree:
+      kind: SelectStatement
+      children:
+        - Tree:
+            kind: SelectClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: SELECT
+                  start: 548
+                  end: 554
+                  line: 20
+                  column: 1
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 554
+                        end: 555
+                        line: 20
+                        column: 7
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: column_3
+                              start: 555
+                              end: 563
+                              line: 20
+                              column: 8
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 563
+                              end: 564
+                              line: 20
+                              column: 16
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: as
+                              start: 564
+                              end: 566
+                              line: 20
+                              column: 17
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 566
+                              end: 567
+                              line: 20
+                              column: 19
+                          - Token:
+                              kind: BareWord
+                              text: c3
+                              start: 567
+                              end: 569
+                              line: 20
+                              column: 20
+                    - Token:
+                        kind: Comma
+                        text: ","
+                        start: 569
+                        end: 570
+                        line: 20
+                        column: 22
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 570
+                        end: 571
+                        line: 20
+                        column: 23
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: json
+                              start: 571
+                              end: 575
+                              line: 20
+                              column: 24
+                          - Token:
+                              kind: Dot
+                              text: "."
+                              start: 575
+                              end: 576
+                              line: 20
+                              column: 28
+                          - Tree:
+                              kind: ColumnReference
+                              children:
+                                - Token:
+                                    kind: BareWord
+                                    text: nested
+                                    start: 576
+                                    end: 582
+                                    line: 20
+                                    column: 29
+                                - Token:
+                                    kind: Dot
+                                    text: "."
+                                    start: 582
+                                    end: 583
+                                    line: 20
+                                    column: 35
+                                - Tree:
+                                    kind: ColumnReference
+                                    children:
+                                      - Token:
+                                          kind: BareWord
+                                          text: path
+                                          start: 583
+                                          end: 587
+                                          line: 20
+                                          column: 36
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 587
+                                          end: 588
+                                          line: 20
+                                          column: 40
+                    - Tree:
+                        kind: ColumnAlias
+                        children:
+                          - Token:
+                              kind: QuotedIdentifier
+                              text: "\"jsonNestedPath\""
+                              start: 588
+                              end: 604
+                              line: 20
+                              column: 41
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 604
+                        end: 605
+                        line: 20
+                        column: 57
+        - Tree:
+            kind: FromClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: FROM
+                  start: 605
+                  end: 609
+                  line: 20
+                  column: 58
+              - Tree:
+                  kind: TableIdentifier
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 609
+                        end: 610
+                        line: 20
+                        column: 62
+                    - Token:
+                        kind: BareWord
+                        text: table3
+                        start: 610
+                        end: 616
+                        line: 20
+                        column: 63
+  - Token:
+      kind: Semicolon
+      text: ;
+      start: 616
+      end: 617
+      line: 20
+      column: 69
+  - Token:
+      kind: Whitespace
+      text: "\n"
+      start: 617
+      end: 618
+      line: 20
+      column: 70
+  - Tree:
+      kind: SelectStatement
+      children:
+        - Tree:
+            kind: FromClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: FROM
+                  start: 618
+                  end: 622
+                  line: 21
+                  column: 1
+              - Tree:
+                  kind: TableIdentifier
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 622
+                        end: 623
+                        line: 21
+                        column: 5
+                    - Token:
+                        kind: BareWord
+                        text: system
+                        start: 623
+                        end: 629
+                        line: 21
+                        column: 6
+                    - Token:
+                        kind: Dot
+                        text: "."
+                        start: 629
+                        end: 630
+                        line: 21
+                        column: 12
+                    - Token:
+                        kind: BareWord
+                        text: numbers
+                        start: 630
+                        end: 637
+                        line: 21
+                        column: 13
+        - Tree:
+            kind: SelectClause
+            children:
+              - Token:
+                  kind: Whitespace
+                  text: " "
+                  start: 637
+                  end: 638
+                  line: 21
+                  column: 20
+              - Token:
+                  kind: BareWord
+                  text: SELECT
+                  start: 638
+                  end: 644
+                  line: 21
+                  column: 21
+              - Tree:
+                  kind: ColumnList
+                  children:
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 644
+                        end: 645
+                        line: 21
+                        column: 27
+                    - Tree:
+                        kind: ColumnReference
+                        children:
+                          - Token:
+                              kind: BareWord
+                              text: number
+                              start: 645
+                              end: 651
+                              line: 21
+                              column: 28
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 651
+                              end: 652
+                              line: 21
+                              column: 34
+        - Tree:
+            kind: WhereClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: WHERE
+                  start: 652
+                  end: 657
+                  line: 21
+                  column: 35
+              - Token:
+                  kind: Whitespace
+                  text: " "
+                  start: 657
+                  end: 658
+                  line: 21
+                  column: 40
+              - Tree:
+                  kind: BinaryExpression
+                  children:
+                    - Tree:
+                        kind: BinaryExpression
+                        children:
+                          - Tree:
+                              kind: BinaryExpression
+                              children:
+                                - Tree:
+                                    kind: ColumnReference
+                                    children:
+                                      - Token:
+                                          kind: BareWord
+                                          text: number
+                                          start: 658
+                                          end: 664
+                                          line: 21
+                                          column: 41
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 664
+                                          end: 665
+                                          line: 21
+                                          column: 47
+                                - Token:
+                                    kind: Greater
+                                    text: ">"
+                                    start: 665
+                                    end: 666
+                                    line: 21
+                                    column: 48
+                                - Token:
+                                    kind: Whitespace
+                                    text: " "
+                                    start: 666
+                                    end: 667
+                                    line: 21
+                                    column: 49
+                                - Tree:
+                                    kind: NumberLiteral
+                                    children:
+                                      - Token:
+                                          kind: Number
+                                          text: "1"
+                                          start: 667
+                                          end: 668
+                                          line: 21
+                                          column: 50
+                                - Token:
+                                    kind: Whitespace
+                                    text: " "
+                                    start: 668
+                                    end: 669
+                                    line: 21
+                                    column: 51
+                          - Token:
+                              kind: BareWord
+                              text: OR
+                              start: 669
+                              end: 671
+                              line: 21
+                              column: 52
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 671
+                              end: 672
+                              line: 21
+                              column: 54
+                          - Tree:
+                              kind: BinaryExpression
+                              children:
+                                - Tree:
+                                    kind: ColumnReference
+                                    children:
+                                      - Token:
+                                          kind: BareWord
+                                          text: number
+                                          start: 672
+                                          end: 678
+                                          line: 21
+                                          column: 55
+                                      - Token:
+                                          kind: Whitespace
+                                          text: " "
+                                          start: 678
+                                          end: 679
+                                          line: 21
+                                          column: 61
+                                - Token:
+                                    kind: Less
+                                    text: "<"
+                                    start: 679
+                                    end: 680
+                                    line: 21
+                                    column: 62
+                                - Token:
+                                    kind: Whitespace
+                                    text: " "
+                                    start: 680
+                                    end: 681
+                                    line: 21
+                                    column: 63
+                                - Tree:
+                                    kind: NumberLiteral
+                                    children:
+                                      - Token:
+                                          kind: Number
+                                          text: "5"
+                                          start: 681
+                                          end: 682
+                                          line: 21
+                                          column: 64
+                                - Token:
+                                    kind: Whitespace
+                                    text: " "
+                                    start: 682
+                                    end: 683
+                                    line: 21
+                                    column: 65
+                    - Token:
+                        kind: BareWord
+                        text: AND
+                        start: 683
+                        end: 686
+                        line: 21
+                        column: 66
+                    - Token:
+                        kind: Whitespace
+                        text: " "
+                        start: 686
+                        end: 687
+                        line: 21
+                        column: 69
+                    - Tree:
+                        kind: BinaryExpression
+                        children:
+                          - Tree:
+                              kind: NumberLiteral
+                              children:
+                                - Token:
+                                    kind: Number
+                                    text: "1"
+                                    start: 687
+                                    end: 688
+                                    line: 21
+                                    column: 70
+                          - Token:
+                              kind: Equals
+                              text: "="
+                              start: 688
+                              end: 689
+                              line: 21
+                              column: 71
+                          - Tree:
+                              kind: NumberLiteral
+                              children:
+                                - Token:
+                                    kind: Number
+                                    text: "1"
+                                    start: 689
+                                    end: 690
+                                    line: 21
+                                    column: 72
+                          - Token:
+                              kind: Whitespace
+                              text: " "
+                              start: 690
+                              end: 691
+                              line: 21
+                              column: 73
+        - Tree:
+            kind: LimitClause
+            children:
+              - Token:
+                  kind: BareWord
+                  text: LIMIT
+                  start: 691
+                  end: 696
+                  line: 21
+                  column: 74
+              - Token:
+                  kind: Whitespace
+                  text: " "
+                  start: 696
+                  end: 697
+                  line: 21
+                  column: 79
+              - Tree:
+                  kind: NumberLiteral
+                  children:
+                    - Token:
+                        kind: Number
+                        text: "1"
+                        start: 697
+                        end: 698
+                        line: 21
+                        column: 80
+  - Token:
+      kind: Semicolon
+      text: ;
+      start: 698
+      end: 699
+      line: 21
+      column: 81


### PR DESCRIPTION
This PR adds a setup for testing the parser output using snapshots. Snapshots should make it easier to detect and review changes and regressions in parser output. Snapshot testing should also simplify the process of creating new test cases - just add a new SQL file in the test/input directory.

In the future, we could also run other functions, such as `analyze` on the same sets of input files.

`cargo-insta`, the tool used for maintaining and reviewing snapshots, provides nice formats for snapshots, provided the value being snapshotted implements Serde's Serialize trait. I have derived Serialize on `Tree` and its children so that the output can be stored in YAML. We could instead use the output of Tree's `print()` function, though my thought is that (a) print may be for display purposes and should be allowed to change its formatting without breaking all parser tests, while the structure of the tree data and thus how it is serialized by serde should not change unless the API is changing. Further, (b) using Serde could allow us to return a more structured value to wasm consumers through [serde_wasm_bindgen](https://docs.rs/serde-wasm-bindgen/latest/serde_wasm_bindgen/) in the future.

